### PR TITLE
#377 - add visual feedback for swipe motion

### DIFF
--- a/_dprhtml/js/chrome.js
+++ b/_dprhtml/js/chrome.js
@@ -467,6 +467,7 @@ const DPR_Chrome_UI = (function () {
 
     // Add event listeners for swipe gestures
     window.DPR_Mediator.emit('DPR_Swipe_Gesture:touchstart', getSectionElementIdName(sPos))
+    window.DPR_Mediator.emit('DPR_Swipe_Gesture:touchmove', getSectionElementIdName(sPos))
     window.DPR_Mediator.emit('DPR_Swipe_Gesture:touchend', getSectionElementIdName(sPos), sPos)
   }
 

--- a/_dprhtml/js/swipe_gestures.js
+++ b/_dprhtml/js/swipe_gestures.js
@@ -5,10 +5,11 @@ const DPR_Swipe_Gesture = (function () {
   let startX = null;
   let startY = null;
   let startTime = null;
+  let backgroundProp = ""
   //swipe must have 40px min on the X axis
-  const minSwipeX = 40;
+  const minSwipeX = $(window).width() / 10 || 40;
   //movement on X should be at least this times more than on Y
-  const swipeRatioThreshold = 0.6;
+  const swipeRatioThreshold = 1.2;
   // typical swipe speeds vary between 0.1 and 0.6
   const speedThreshold = 0.19;
   // acceptable variation around thresholds ( accept lower speed + high ratio or vice-versa )
@@ -22,13 +23,21 @@ const DPR_Swipe_Gesture = (function () {
         .addEventListener('touchstart', DPR_Gesture.touchStart, true)
     },
   )
+  window.DPR_Mediator.on(
+    'DPR_Swipe_Gesture:touchmove', 
+    (sectionElementId) => {
+      document
+        .getElementById(sectionElementId)
+        .addEventListener('touchmove', DPR_Gesture.touchMoveFactory(sectionElementId), true)
+    },
+  )
 
     window.DPR_Mediator.on(
       'DPR_Swipe_Gesture:touchend', 
       (sectionElementId, sectionPosition) => {
         document
           .getElementById(sectionElementId)
-          .addEventListener('touchend', DPR_Gesture.touchEndFactory(sectionPosition), true)
+          .addEventListener('touchend', DPR_Gesture.touchEndFactory(sectionElementId, sectionPosition), true)
       },
     )
   
@@ -47,8 +56,21 @@ const DPR_Swipe_Gesture = (function () {
     }
   }
 
-  const touchEndFactory = function (sectionPosition) {
-    return function touchEnd(event) {
+  const touchMoveFactory = (id) =>  {
+    return (event) => {
+      const tempX =  event.changedTouches.item(0).clientX;
+      const tempY = event.changedTouches.item(0).clientY;
+      const swipeXDiff = tempX - startX;
+      const swipeYDiff = tempY - startY;
+      let section = document.getElementById(id);
+
+      applyMoveEffects(section, swipeXDiff);
+    }
+    
+  }
+
+  const touchEndFactory = (sectionElementId, sectionPosition) => {
+    return (event) => {
       if (startX || startY) {
         //the only finger that hit the screen left it
         const endX = event.changedTouches.item(0).clientX;
@@ -62,6 +84,8 @@ const DPR_Swipe_Gesture = (function () {
         const speed = distance / timeDiff;
         // the ratio is logarithmic in order to adjust for the exponential curve of the ratio (this facilitates applying the skew factor)
         const horizontalToVerticalRatio = Math.log2(Math.abs(swipeXDiff / swipeYDiff));
+        let section = document.getElementById(sectionElementId);
+        resetSectionLook(section);
 
         if (matchesSwipeCriteria(horizontalToVerticalRatio, speed)) {
           if (endX > startX + minSwipeX) {
@@ -107,6 +131,28 @@ const DPR_Swipe_Gesture = (function () {
     }
   }
 
+  const applyMoveEffects = (section, swipeXDiff, swipeYDiff) => {
+    if (Math.abs(swipeXDiff) > minSwipeX && Math.abs(swipeXDiff) < 2 * minSwipeX) {
+      section.style.left = swipeXDiff + "px";
+      section.style.top = swipeYDiff  + "px";
+      section.style.position = "relative";
+      section.style.zIndex = "9999999";
+      section.classList.add("paperback");
+      backgroundProp = section.style.background;
+      section.style.background = "";
+    }
+    
+  }
+
+  const resetSectionLook = (section) => {
+    section.style.left = "";
+    section.style.top = "";
+    section.style.position = "";
+    section.style.zIndex = "";
+    section.classList.remove("paperback");
+    section.style.background = backgroundProp;
+  }
+
   const runMatchingCommand = (e) => {
     const cmd = Object.entries(window.DPR_Globals.DprViewModel.commands).find(([_, x]) => x().matchGesture(e));
     if (cmd && !cmd[1]().notImplemented && cmd[1]().canExecute && cmd[1]().visible) {
@@ -119,6 +165,7 @@ const DPR_Swipe_Gesture = (function () {
   return {
     touchStart,
     touchEndFactory,
+    touchMoveFactory,
   };
 
 })();


### PR DESCRIPTION
Increase the vertical to horizontal threshold, to make a clearer distinction between scrolling and swiping.

Now using the screen size to calculate the minimum swipe threshold - this is determined using jQuery, since JS code to check in a reliable way on all devices is messy.

Add a listener for touch move which creates an effect of shifting the section to a side if your touch gesture moves a certain amount laterally. The effect is achieved with inline styles. The inline styles are cleared on the touchEnd event with "resetSectionLook()".

Closes #377 

